### PR TITLE
Update resource mapping server extensibility

### DIFF
--- a/source/Server/Configuration/UsernamePasswordConfigurationSettings.cs
+++ b/source/Server/Configuration/UsernamePasswordConfigurationSettings.cs
@@ -8,8 +8,7 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.Configura
     {
 
         public UsernamePasswordConfigurationSettings(
-            IUsernamePasswordConfigurationStore configurationStore,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IUsernamePasswordConfigurationStore configurationStore) : base(configurationStore)
         {
         }
 
@@ -24,10 +23,9 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.Configura
             yield return new ConfigurationValue("Octopus.UsernamePassword.IsEnabled", ConfigurationDocumentStore.GetIsEnabled().ToString(), ConfigurationDocumentStore.GetIsEnabled(), "Is Enabled");
         }
 
-        public override IEnumerable<IResourceMapping> GetMappings()
+        public override void BuildMappings(IResourceMappingsBuilder builder)
         {
-            return new [] { ResourceMappingFactory
-                .Create<UsernamePasswordConfigurationResource, UsernamePasswordConfiguration>() };
+            builder.Map<UsernamePasswordConfigurationResource, UsernamePasswordConfiguration>();
         }
     }
 }

--- a/source/Server/Configuration/UsernamePasswordConfigurationStore.cs
+++ b/source/Server/Configuration/UsernamePasswordConfigurationStore.cs
@@ -1,6 +1,5 @@
 ﻿using Octopus.Data.Storage.Configuration;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 
 namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.Configuration
 {
@@ -9,8 +8,7 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.Configura
         public static string SingletonId = "authentication-usernamepassword";
 
         public UsernamePasswordConfigurationStore(
-            IConfigurationStore configurationStore,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IConfigurationStore configurationStore) : base(configurationStore)
         {
         }
 

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="NuGet.Versioning" Version="3.4.3" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.11" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.12" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
-    <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="5.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="5.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="5.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="5.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.1.2" />
 
     <Reference Include="System" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="NuGet.Versioning" Version="3.4.3" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.11" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.12" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="5.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="5.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.1.2" />
 


### PR DESCRIPTION
The resource mapping part of `Octopus.Server.Extensibility` has changed. I'm updating this solution accordingly.