### PR TITLE
Support typed config values

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var bin451 = "/bin/Release/net451/";
+var bin452 = "/bin/Release/net452/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json
@@ -91,7 +91,7 @@ Task("__Pack")
         CreateDirectory(odNugetPackDir);
         CopyFileToDirectory(Path.Combine(assetDir, nuspecFile), odNugetPackDir);
 
-        CopyFileToDirectory(solutionDir + "Server" + bin451 + "Octopus.Server.Extensibility.Authentication.UsernamePassword.dll", odNugetPackDir);
+        CopyFileToDirectory(solutionDir + "Server" + bin452 + "Octopus.Server.Extensibility.Authentication.UsernamePassword.dll", odNugetPackDir);
 
         NuGetPack(Path.Combine(odNugetPackDir, nuspecFile), new NuGetPackSettings {
             Version = nugetVersion,

--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="4.42.4" />
+    <PackageReference Include="Octopus.Client" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <RootNamespace>Octopus.Client.Extensibility.Authentication.UsernamePassword</RootNamespace>
     <AssemblyName>Octopus.Client.Extensibility.Authentication.UsernamePassword</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/source/Server/Configuration/UsernamePasswordConfigurationSettings.cs
+++ b/source/Server/Configuration/UsernamePasswordConfigurationSettings.cs
@@ -18,9 +18,9 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.Configura
 
         public override string Description => "Usernames and passwords managed by Octopus";
 
-        public override IEnumerable<ConfigurationValue> GetConfigurationValues()
+        public override IEnumerable<IConfigurationValue> GetConfigurationValues()
         {
-            yield return new ConfigurationValue("Octopus.UsernamePassword.IsEnabled", ConfigurationDocumentStore.GetIsEnabled().ToString(), ConfigurationDocumentStore.GetIsEnabled(), "Is Enabled");
+            yield return new ConfigurationValue<bool>("Octopus.UsernamePassword.IsEnabled", ConfigurationDocumentStore.GetIsEnabled(), ConfigurationDocumentStore.GetIsEnabled(), "Is Enabled");
         }
 
         public override void BuildMappings(IResourceMappingsBuilder builder)

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.2.2" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.2" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.3" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.4-enh-typedconfig0001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.2.2" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.4-enh-typedconfig0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.1.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -4,7 +4,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.UsernamePassword</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.UsernamePassword</AssemblyName>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>


### PR DESCRIPTION
Relates to OctopusDeploy/ServerExtensibility#12 and https://github.com/OctopusDeploy/AuthenticationExtensibility/pull/10

Allow config values to use their base type (int/bool/string), rather than casting everything to a string