### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var bin = "/bin/Release/netstandard2.0/";
+var bin = "/bin/Release/netstandard2.1/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -16,10 +16,9 @@
   <ItemGroup>
     <!-- These packages are copied to the output directory during the build process -->
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Octopus.Data" Version="5.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -4,20 +4,21 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.UsernamePassword</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.UsernamePassword</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Octopus Deploy</Authors>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/UsernamePasswordAuthenticationProvider/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpressions>Apache-2.0</PackageLicenseExpressions>
     <PackageProjectUrl>https://github.com/OctopusDeploy/UsernamePasswordAuthenticationProvider</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- These packages are copied to the output directory during the build process -->
-    <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.0" />
+    <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0004" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0005" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0005" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -16,9 +16,9 @@
   <ItemGroup>
     <!-- These packages are copied to the output directory during the build process -->
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -10,15 +10,16 @@
     <PackageLicenseExpressions>Apache-2.0</PackageLicenseExpressions>
     <PackageProjectUrl>https://github.com/OctopusDeploy/UsernamePasswordAuthenticationProvider</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- These packages are copied to the output directory during the build process -->
-    <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
+    <PackageReference Include="Octopus.Data" Version="5.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,10 +15,10 @@
   <ItemGroup>
     <!-- These packages are copied to the output directory during the build process -->
     <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0004" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0005" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0005" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
+++ b/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
@@ -24,7 +24,7 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.UsernameP
 
         public int Priority => 50;
 
-        public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
+        public IResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())
             {

--- a/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
+++ b/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
@@ -1,8 +1,9 @@
 ﻿using System.Linq;
 using System.Threading;
+using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
-using Octopus.Server.Extensibility.Authentication.Storage.User;
 using Octopus.Server.Extensibility.Authentication.UsernamePassword.Configuration;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.UsernamePasswordAuth
 {
@@ -21,11 +22,11 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.UsernameP
 
         public int Priority => 50;
 
-        public AuthenticationUserCreateResult ValidateCredentials(string username, string password, CancellationToken cancellationToken)
+        public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())
             {
-                return new AuthenticationUserCreateResult();
+                return ResultFromExtension<IUser>.ExtensionDisabled();
             }
 
             var user = userStore.GetByUsername(username);
@@ -41,10 +42,10 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.UsernameP
 
             if (user != null && user.ValidatePassword(password))
             {
-                return new AuthenticationUserCreateResult(user);
+                return ResultFromExtension<IUser>.Success(user);
             }
 
-            return new AuthenticationUserCreateResult("Invalid username or password.");
+            return ResultFromExtension<IUser>.Failed("Invalid username or password.");
         }
     }
 }

--- a/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
+++ b/source/Server/UsernamePasswordAuth/UsernamePasswordCredentialValidator.cs
@@ -20,6 +20,8 @@ namespace Octopus.Server.Extensibility.Authentication.UsernamePassword.UsernameP
             this.userStore = userStore;
         }
 
+        public string IdentityProviderName => UsernamePasswordAuthenticationProvider.ProviderName;
+
         public int Priority => 50;
 
         public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility and AuthenticationExtensibility.

Depends on:
OctopusDeploy/AuthenticationExtensibility#15